### PR TITLE
Fix the name of a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Dependencies
 You need the following libraries before compiling :
 
   * cmake  ( ```$ sudo apt-get install cmake``` ),
-  * GTest  ( ```$ sudo apt-get install gtest-dev``` ),
+  * GTest  ( ```$ sudo apt-get install libgtest-dev``` ),
   * OpenCV ( ```$ sudo apt-get install libopencv-dev``` )
 
 How to build the program


### PR DESCRIPTION
The name of the package containing the dependency GTest, at least on Debian 9, is  `libgtest-dev` and not `gtest-dev`